### PR TITLE
Refer to worker chart by SHA instead of ref for idempotent deployments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -224,7 +224,7 @@ jobs:
           | yq w -d0 - metadata.name "$DEPLOYMENT_NAME-$SANDBOX_ID" \
           | yq w -d1 - metadata.tags.githubSha "$GITHUB_SHA" \
           | yq w -d1 - spec.releaseName "$DEPLOYMENT_NAME" \
-          | yq w -d1 - spec.chart.ref "$CHART_REF" \
+          | yq w -d1 - spec.chart.ref "$GITHUB_SHA" \
           | yq w -d1 - spec.values.serviceAccount.iamRole "arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/worker-role-${{ matrix.environment }}" \
           | yq w -d1 - spec.values.images.r "$IMAGE_NAME-r" \
           | yq w -d1 - spec.values.images.python "$IMAGE_NAME-python" \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -211,12 +211,10 @@ jobs:
 
           if [ "${{ matrix.environment }}" = "production" ]; then
             SANDBOX_ID="default"
-            CHART_REF="$GITHUB_SHA"
           fi
 
           if [ "${{ matrix.environment }}" = "staging" ]; then
             SANDBOX_ID="STAGING_SANDBOX_ID"
-            CHART_REF="$GITHUB_REF"
           fi
 
           echo "::set-output name=sandbox-id::$SANDBOX_ID"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -224,7 +224,7 @@ jobs:
           | yq w -d0 - metadata.name "$DEPLOYMENT_NAME-$SANDBOX_ID" \
           | yq w -d1 - metadata.tags.githubSha "$GITHUB_SHA" \
           | yq w -d1 - spec.releaseName "$DEPLOYMENT_NAME" \
-          | yq w -d1 - spec.chart.ref "$GITHUB_REF" \
+          | yq w -d1 - spec.chart.ref "$GITHUB_SHA" \
           | yq w -d1 - spec.values.serviceAccount.iamRole "arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/worker-role-${{ matrix.environment }}" \
           | yq w -d1 - spec.values.images.r "$IMAGE_NAME-r" \
           | yq w -d1 - spec.values.images.python "$IMAGE_NAME-python" \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -211,10 +211,12 @@ jobs:
 
           if [ "${{ matrix.environment }}" = "production" ]; then
             SANDBOX_ID="default"
+            CHART_REF="$GITHUB_SHA"
           fi
 
           if [ "${{ matrix.environment }}" = "staging" ]; then
             SANDBOX_ID="STAGING_SANDBOX_ID"
+            CHART_REF="$GITHUB_REF"
           fi
 
           echo "::set-output name=sandbox-id::$SANDBOX_ID"
@@ -224,7 +226,7 @@ jobs:
           | yq w -d0 - metadata.name "$DEPLOYMENT_NAME-$SANDBOX_ID" \
           | yq w -d1 - metadata.tags.githubSha "$GITHUB_SHA" \
           | yq w -d1 - spec.releaseName "$DEPLOYMENT_NAME" \
-          | yq w -d1 - spec.chart.ref "$GITHUB_SHA" \
+          | yq w -d1 - spec.chart.ref "$CHART_REF" \
           | yq w -d1 - spec.values.serviceAccount.iamRole "arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/worker-role-${{ matrix.environment }}" \
           | yq w -d1 - spec.values.images.r "$IMAGE_NAME-r" \
           | yq w -d1 - spec.values.images.python "$IMAGE_NAME-python" \


### PR DESCRIPTION
This ensures that each staging environment is pinned to the chart that was latest when the deployment was created.. This is so we don't end up with changing environments deployed previously if the worker chart gets updated.