### PR TITLE
Increase liveness probe initial delay

### DIFF
--- a/chart-instance/templates/job.yaml
+++ b/chart-instance/templates/job.yaml
@@ -51,7 +51,7 @@ spec:
             path: /health
             port: 4000
           initialDelaySeconds: 30
-          periodSeconds: 10
+          periodSeconds: 20
       volumes:
       - name: 'data'
         persistentVolumeClaim:

--- a/chart-instance/templates/job.yaml
+++ b/chart-instance/templates/job.yaml
@@ -50,7 +50,7 @@ spec:
           httpGet:
             path: /health
             port: 4000
-          initialDelaySeconds: 5
+          initialDelaySeconds: 30
           periodSeconds: 10
       volumes:
       - name: 'data'


### PR DESCRIPTION
We have the R worker failing the liveness probe sometimes. This happens when the worker is still downloading the files so the R worker is not ready and it doesn't spin up the HTTP server. We should wait at least 30 seconds before we query the R worker.