### PR TITLE
Lock pagoda version and update readme for linux users

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,18 @@ For more details on the individual runners, check out the README files in their 
     This error is due to a bug in DNS resolution of Alpine-based containers running on early releases of Docker Desktop for Mac version 3.
 
     To fix this, you can download and use a previous version of Docker (e.g. 2.5.0.1) from https://docs.docker.com/docker-for-mac/release-notes/
+    
+### For linux users
+
+1. Error when attempting to start the worker saying something like:
+`botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL: "http://host.docker.internal:4566/biomage-source-development?...`
+
+Go to `docker-compose.yml`
+In the python and r entries add at the end:
+
+```
+extra_hosts:
+      - "host.docker.internal:host-gateway"
+```
+
+IMPORTANT: Don't include this in a PR, because it will break stuff on macOS.

--- a/r/Dockerfile
+++ b/r/Dockerfile
@@ -23,7 +23,7 @@ RUN Rscript setup/install_or_die.r BiocManager
 RUN R -e 'BiocManager::install(c("AnnotationDbi", "BiocGenerics", "GO.db", "pcaMethods", "org.Dr.eg.db", "org.Hs.eg.db", "org.Mm.eg.db"))'
 
 RUN R -e 'install.packages("RcppSpdlog")'
-RUN R -e 'devtools::install_github("kharchenkolab/pagoda2")'
+RUN R -e 'devtools::install_github("kharchenkolab/pagoda2@v0.1.4")'
 RUN R -e 'devtools::install_github("kharchenkolab/conos@v1.3.1")'
 
 RUN R -e 'install.packages("gprofiler2")'


### PR DESCRIPTION
# Background
When the differential expression is run, the R worker uses the pagoda function getDifferentialGenes, which seems to not be available in newer versions of pagoda, so this library should be locked to a version that does have it in order to have the differential expression run correctly.

#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-449?atlOrigin=eyJpIjoiYjNjNDQ2OGQ1YTlmNDA5ZWIyYTdiNGQzNjAyY2ZjYzEiLCJwIjoiaiJ9

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here
Added an item to the readme with a possible fix for an issue linux users may run into.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
