### PR TITLE
Disable KubeBot reporting on unused volume cleanup service

### DIFF
--- a/chart-infra/templates/unused-volume-cleanup.yaml
+++ b/chart-infra/templates/unused-volume-cleanup.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     sandboxId: "{{ .Values.sandboxId }}"
+  annotations:
+    botkube.io/disable: true
 spec:
   schedule: "0 * * * *"
   concurrencyPolicy: Replace


### PR DESCRIPTION
# Background
#### Link to issue
https://biomage.atlassian.net/browse/BIOMAGE-466

#### Link to staging deployment URL
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes

Added the annotation `botkube.io/disable: true` to the unused volume cleanup service. This is mentioned in a random place at [the botkube docs site](https://www.botkube.io/usage/). This will prevent the unused volume cleanup service to send error messages to #incidents when a running worker does not release its volume as it's being used.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [x] Photo of a cute animal attached to this PR
![image](https://user-images.githubusercontent.com/16019444/105169589-a4a95880-5b13-11eb-9fd7-7eb49506b216.png)
