### PR TITLE
Add a remoter::server script which runs once and exposes a function c…

### DIFF
--- a/docker-compose.linux-dev.yaml
+++ b/docker-compose.linux-dev.yaml
@@ -27,3 +27,17 @@ services:
       - ./data:/data:cached
     extra_hosts:
       - "host.docker.internal:host-gateway"
+  qcserver:
+    container_name: 'biomage-worker-qserver'
+    build:
+      context: r/
+      target: qcserver-dev
+    volumes:
+      - ./r:/r:cached
+    expose:
+      - "55555"
+    ports:
+      - "55555:55555"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,17 @@ services:
     volumes:
       - ./python:/python:cached
       - ./data:/data:cached
+  qcserver:
+    container_name: 'biomage-worker-qserver'
+    build:
+      context: r/
+      target: qcserver-dev
+    volumes:
+      - ./r:/r:cached
+    expose:
+      - "55555"
+    ports:
+      - "55555:55555"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+

--- a/r/Dockerfile
+++ b/r/Dockerfile
@@ -30,7 +30,7 @@ RUN R -e 'install.packages("gprofiler2")'
 RUN R -e 'install.packages("RJSONIO")'
 
 # ---------------------------------------------------
-# PRODUCTION BUILD
+# WORKER PRODUCTION BUILD
 # ---------------------------------------------------
 FROM builder AS prod
 
@@ -42,7 +42,7 @@ ENTRYPOINT ["bash", "/var/lib/watchfile/entrypoint.sh"]
 CMD ["Rscript", "work.r"]
 
 # ---------------------------------------------------
-# DEVELOPMENT BUILD
+# WORKER DEVELOPMENT BUILD
 # ---------------------------------------------------
 FROM builder AS dev
 
@@ -56,3 +56,20 @@ ENV EXPERIMENT_ID $EXPERIMENT_ID
 
 WORKDIR /r
 CMD watchmedo auto-restart --directory=./src/ --pattern=* --recursive -- Rscript src/work.r
+
+# ---------------------------------------------------
+# QCSERVER DEVELOPMENT BUILD
+# ---------------------------------------------------
+FROM builder AS qcserver-dev
+
+# install Radian for interactive R shell
+# also install watchdog to automatically restart
+# when source files change
+RUN pip install -U jedi radian PyYAML watchdog[watchmedo]
+
+WORKDIR /r
+RUN R -e 'install.packages("remoter")'
+
+CMD Rscript qcserver/main.R
+
+

--- a/r/qcserver/main.R
+++ b/r/qcserver/main.R
@@ -1,0 +1,8 @@
+
+source("qcserver/wrapper.R")
+
+# Start remoter::server on its default port
+# in debug mode for now (which might be desirable even in prod).
+# The server will shut down when a client runs shutdown() in a session.
+remoter::server(port = 55555, showmsg = TRUE)
+

--- a/r/qcserver/wrapper.R
+++ b/r/qcserver/wrapper.R
@@ -1,0 +1,7 @@
+# dummy object for placeholder
+count_matrix <- 1
+
+wrapper <- function(filter_name) {
+    print(paste(count_matrix, "placeholder wrapper function, running filter", filter_name))
+    count_matrix <<- count_matrix + 1
+}


### PR DESCRIPTION
…alled wrapper() to any connected remoter::client

# Background
#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
