### PR TITLE
Fix R worker breaking in local development

### DIFF
--- a/chart-infra/templates/unused-volume-cleanup.yaml
+++ b/chart-infra/templates/unused-volume-cleanup.yaml
@@ -13,6 +13,8 @@ spec:
   jobTemplate:
     spec:
       template:
+        annotations:
+          botkube.io/disable: "true"
         spec:
           serviceAccountName: unused-volume-cleanup
           restartPolicy: OnFailure

--- a/chart-infra/templates/unused-volume-cleanup.yaml
+++ b/chart-infra/templates/unused-volume-cleanup.yaml
@@ -13,8 +13,9 @@ spec:
   jobTemplate:
     spec:
       template:
-        annotations:
-          botkube.io/disable: "true"
+        metadata:
+          annotations:
+            botkube.io/disable: "true"
         spec:
           serviceAccountName: unused-volume-cleanup
           restartPolicy: OnFailure

--- a/chart-instance/templates/job.yaml
+++ b/chart-instance/templates/job.yaml
@@ -55,9 +55,9 @@ spec:
           httpGet:
             path: /health
             port: 4000
-          initialDelaySeconds: 15
-          periodSeconds: 30
-          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 15
+          failureThreshold: 6
       volumes:
       - name: 'data'
         persistentVolumeClaim:

--- a/r/Dockerfile
+++ b/r/Dockerfile
@@ -55,5 +55,5 @@ RUN pip install -U jedi radian PyYAML watchdog[watchmedo]
 ARG EXPERIMENT_ID
 ENV EXPERIMENT_ID $EXPERIMENT_ID
 
-WORKDIR /r
-CMD watchmedo auto-restart --directory=./src/ --pattern=* --recursive -- Rscript src/work.r
+WORKDIR /r/src
+CMD watchmedo auto-restart --directory=. --pattern=* --recursive -- Rscript work.r


### PR DESCRIPTION
# Background
#### Link to issue 
N/A

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
Also changed the liveness probe requirements to make sure the system does not spew unnecessary errors into #incidents. 

# Changes
### Code changes
Changed way the local development container handles paths -- the path is now relative to `r/src`, like all the other ones.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [x] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
