### PR TITLE
Change default EXPERIMENT_ID

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       target: dev
       args:
         - GITHUB_PAT=${GITHUB_PAT}
-        - EXPERIMENT_ID=5e959f9c9f4b120771249001
+        - EXPERIMENT_ID=5928a56c7cbff9de78974ab50765ed20
     volumes:
       - ./r:/r:cached
       - ./data:/data:cached

--- a/python/src/config/__init__.py
+++ b/python/src/config/__init__.py
@@ -14,7 +14,7 @@ def get_config():
 
     aws_account_id = os.getenv("AWS_ACCOUNT_ID", default="242905224710")
     aws_region = os.getenv("AWS_DEFAULT_REGION", default="eu-west-1")
-    experiment_id = os.getenv("EXPERIMENT_ID", default="5e959f9c9f4b120771249001")
+    experiment_id = os.getenv("EXPERIMENT_ID", default="5928a56c7cbff9de78974ab50765ed20")
     
     # set up cluster env based on gitlab env if one was not specified
     # this is only run if `kube_env` is specified, i.e. when the system

--- a/python/src/tests/helpers/test_count_matrix.py
+++ b/python/src/tests/helpers/test_count_matrix.py
@@ -48,7 +48,7 @@ class TestCountMatrix:
         self.get_count_matrix_instance()
         objs = self.count_matrix.get_objects()
         assert objs == {
-            "5e959f9c9f4b120771249001/python.h5ad": '"864fb08f98f18cb19c7dd04409d90405-18"'
+            "5928a56c7cbff9de78974ab50765ed20/python.h5ad": '"864fb08f98f18cb19c7dd04409d90405-18"'
         }
 
     @mock_s3

--- a/python/src/tests/tasks/test_cluster_cells.py
+++ b/python/src/tests/tasks/test_cluster_cells.py
@@ -19,7 +19,7 @@ class TestClusterCells:
     @pytest.fixture(autouse=True)
     def load_correct_definition(self):
         self.correct_request = {
-            "experimentId": "5e959f9c9f4b120771249001",
+            "experimentId": "5928a56c7cbff9de78974ab50765ed20",
             "timeout": "2099-12-31 00:00:00",
             "body": {
                 "name": "ClusterCells",
@@ -49,7 +49,7 @@ class TestClusterCells:
 
     def test_leiden_clustering_works(self):
         alternative_request = {
-            "experimentId": "5e959f9c9f4b120771249001",
+            "experimentId": "5928a56c7cbff9de78974ab50765ed20",
             "timeout": "2099-12-31 00:00:00",
             "body": {
                 "name": "ClusterCells",

--- a/python/src/tests/tasks/test_differential_expression.py
+++ b/python/src/tests/tasks/test_differential_expression.py
@@ -128,7 +128,7 @@ class TestDifferentialExpression:
         self, cellSet="cluster1", compareWith="rest", basis="all", maxNum=None
     ):
         request = {
-            "experimentId": "5e959f9c9f4b120771249001",
+            "experimentId": "5928a56c7cbff9de78974ab50765ed20",
             "timeout": "2099-12-31 00:00:00",
             "body": {
                 "name": "DifferentialExpression",

--- a/python/src/tests/tasks/test_gene_expression.py
+++ b/python/src/tests/tasks/test_gene_expression.py
@@ -19,7 +19,7 @@ class TestGeneExpression:
     @pytest.fixture(autouse=True)
     def load_correct_definition(self):
         self.correct_request = {
-            "experimentId": "5e959f9c9f4b120771249001",
+            "experimentId": "5928a56c7cbff9de78974ab50765ed20",
             "timeout": "2099-12-31 00:00:00",
             "body": {
                 "name": "GeneExpression",

--- a/r/src/work.r
+++ b/r/src/work.r
@@ -10,7 +10,7 @@ source("./embedding.r")
 
 
 load_data <- function() {
-    experiment_id <- Sys.getenv("EXPERIMENT_ID")
+    experiment_id <- Sys.getenv("EXPERIMENT_ID", unset = "5928a56c7cbff9de78974ab50765ed20")
     message(paste("Welcome to Biomage R worker, experiment id", experiment_id))
 
     loaded <- F


### PR DESCRIPTION
# Background

This PR is just to ckeck if default value of the experiment ID of the env config could be the responsible of the 404 in the PR #100 of the UI. https://github.com/biomage-ltd/ui/pull/100. 

#### Link to issue 

#### Link to staging deployment URL 

https://ui-gkpsecnxsrxmzjbi8njhjqm36c.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

https://github.com/biomage-ltd/ui/pull/100

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [X] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
