### PR TITLE
add debian dependencies used to build devtools

### DIFF
--- a/r/requirements_debian.txt
+++ b/r/requirements_debian.txt
@@ -16,3 +16,7 @@ libgit2-dev
 libglpk-dev
 libxt-dev
 libcairo2-dev
+libfreetype6-dev
+libpng-dev
+libtiff5-dev
+libjpeg-dev


### PR DESCRIPTION
# Background
#### Link to issue 

N.A.

#### Link to staging deployment URL 

N.A.

#### Links to any Pull Requests related to this

N.A.

#### Anything else the reviewers should know about the changes here

- New dependencies required for building dependencies of `devtools`. Build failed without these added dependencies,

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
