### PR TITLE
Rm filtered cells id

### DIFF
--- a/r/src/differential_expression.r
+++ b/r/src/differential_expression.r
@@ -21,17 +21,23 @@
 #'              qval            <-- Need to be returned until the UI is changed
 runDE <- function(req){
     
+
+    # Remove filtered cells
+    baseCells <- req$body$baseCells[req$body$baseCells%in%data@meta.data$cells_id]
+    backgroundCells <- req$body$backgroundCells[req$body$backgroundCells%in%data@meta.data$cells_id]
+
     # set up a factor with the appropriate cells
     factor_DE <- rep(
         c("base", "background"),
         c(
-            length(req$body$baseCells),
-            length(req$body$backgroundCells)
+            length(baseCells),
+            length(backgroundCells)
         )
     ) 
 
-    baseCells_barcode <- rownames(data@meta.data)[match(req$body$baseCells, data@meta.data$cells_id)]
-    backgroundCells_barcode <- rownames(data@meta.data)[match(req$body$backgroundCells, data@meta.data$cells_id)]
+
+    baseCells_barcode <- rownames(data@meta.data)[match(baseCells, data@meta.data$cells_id)]
+    backgroundCells_barcode <- rownames(data@meta.data)[match(backgroundCells, data@meta.data$cells_id)]
 
     names(factor_DE) <- c( 
         baseCells_barcode, backgroundCells_barcode

--- a/r/src/differential_expression.r
+++ b/r/src/differential_expression.r
@@ -21,10 +21,11 @@
 #'              qval            <-- Need to be returned until the UI is changed
 runDE <- function(req){
     
+    cells_id <- data@meta.data$cells_id
 
     # Remove filtered cells
-    baseCells <- req$body$baseCells[req$body$baseCells%in%data@meta.data$cells_id]
-    backgroundCells <- req$body$backgroundCells[req$body$backgroundCells%in%data@meta.data$cells_id]
+    baseCells <- req$body$baseCells[req$body$baseCells %in% cells_id]
+    backgroundCells <- req$body$backgroundCells[req$body$backgroundCells %in% cells_id]
 
     # set up a factor with the appropriate cells
     factor_DE <- rep(
@@ -36,8 +37,8 @@ runDE <- function(req){
     ) 
 
 
-    baseCells_barcode <- rownames(data@meta.data)[match(baseCells, data@meta.data$cells_id)]
-    backgroundCells_barcode <- rownames(data@meta.data)[match(backgroundCells, data@meta.data$cells_id)]
+    baseCells_barcode <- rownames(data@meta.data)[match(baseCells, cells_id)]
+    backgroundCells_barcode <- rownames(data@meta.data)[match(backgroundCells, cells_id)]
 
     names(factor_DE) <- c( 
         baseCells_barcode, backgroundCells_barcode


### PR DESCRIPTION
# Background
#### Link to issue 

When doing DE we got an error when comparing samples. The reason of the error is because in dynamo, inside samples, we store the raw information, that is, the filtered and the unfiltered cells. Hence, when the worker fetch all cells id related to a sample, it receives also cells that have been filtered, so we need to handle it in the worker side. 

#### Link to staging deployment URL 

https://ui-juanlu-worker100-pipeline3.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
