### PR TITLE
Fix for bug in heatmap related to non-unique annotated genes

### DIFF
--- a/r/src/expression.r
+++ b/r/src/expression.r
@@ -14,7 +14,7 @@ runExpression <- function(req) {
     genesSubset <- subset(df, toupper(df$name) %in% toupper(req$body$genes))
     #
     #Get the expression values for those genes in the corresponding matrix.
-    geneExpression <-data@assays$RNA@data[genesSubset$input,,drop=FALSE]
+    geneExpression <-data@assays$RNA@data[unique(genesSubset$input),,drop=FALSE]
     geneExpression <- as.data.frame(t(as.matrix(geneExpression)))
     geneExpression$cells_id <- data@meta.data$cells_id
     geneExpression <- geneExpression[ order(geneExpression$cells_id), ]


### PR DESCRIPTION
# Background
#### Link to issue 

Due to being duplicated annotated names for different genes the heatmap would fail for certain genes.

#### Link to staging deployment URL 



#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ X] Photo of a cute animal attached to this PR
![image](https://user-images.githubusercontent.com/76957896/114776440-d9126680-9d48-11eb-8adc-c6de0e66c343.png)
