### PR TITLE
add experimentID as environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - "4000:4000"
     environment:
-      - EXPERIMENT_ID=e52b39624588791a7889e39c617f669e
+      - EXPERIMENT_ID=${EXPERIMENT_ID-e52b39624588791a7889e39c617f669e}
   python:
     container_name: "biomage-worker-python"
     build:
@@ -25,4 +25,4 @@ services:
       - ./python:/python:cached
       - ./data:/data:cached
     environment:
-      - EXPERIMENT_ID=e52b39624588791a7889e39c617f669e
+      - EXPERIMENT_ID=${EXPERIMENT_ID-e52b39624588791a7889e39c617f669e}


### PR DESCRIPTION
# Background
#### Link to issue 

N.A.

#### Link to staging deployment URL 

N.A.

#### Links to any Pull Requests related to this

N.A.

#### Anything else the reviewers should know about the changes here

- Now you can set `EXPERIMENT_ID` as an environment variable when running worker, instead of changing the values in `docker-compose.yaml`

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
