### PR TITLE
Kubernetes jobs don't shut down properly

### DIFF
--- a/chart-infra/templates/kube-cleanup-operator-deployment.yaml
+++ b/chart-infra/templates/kube-cleanup-operator-deployment.yaml
@@ -30,8 +30,9 @@ spec:
         # delete successful and failed jobs after 30 seconds.
         # this is so failed jobs don't prevent us from running
         # new workers in its place
-        - -delete-successful-after=0
-        - -delete-failed-after=0
+        - --legacy-mode=false
+        - --delete-successful-after=1s
+        - --delete-failed-after=1s
         image: quay.io/lwolf/kube-cleanup-operator
         imagePullPolicy: Always
         name: cleanup-operator

--- a/chart-infra/templates/kube-cleanup-operator-deployment.yaml
+++ b/chart-infra/templates/kube-cleanup-operator-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
       - args:
         - --namespace={{.Release.Namespace}}
-        # delete successful and failed jobs after 30 seconds.
+        # delete successful and failed jobs after one second
         # this is so failed jobs don't prevent us from running
         # new workers in its place
         - --legacy-mode=false


### PR DESCRIPTION
# Background
#### Link to issue
https://biomage.atlassian.net/browse/BIOMAGE-601

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes
Kubernetes cleanup operator was not configured properly to delete failed jobs. The code from the relevant (working) part of [pipeline](https://github.com/biomage-ltd/pipeline/blob/master/chart-infra/templates/kube-cleanup-operator-deployment.yaml#L29-L32) was used for this fix.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [x] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [x] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
