### PR TITLE
added autobuild to run command & separate files for linux & mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 PYTHON_FILES?=$$(find python -name '*.py' | grep -v venv) # do not include virtual env files
 # If unix name is Darwin, we are in MacOS => use regular docker-compose.yaml
 # Otherwise assume Linux and add docker-compose.linux-dev.yaml overrides
-ifneq ($(shell uname -s), Darwin)
+ifeq ($(shell uname -s), Darwin)
   docker_files=-f docker-compose.yaml
 else
   docker_files=-f docker-compose.yaml -f docker-compose.linux-dev.yaml
@@ -28,10 +28,12 @@ check: ## Checks code for linting/construct errors
 	flake8 $(PYTHON_FILES)
 	@echo "    [✓]\n"
 build: ## Builds the docker-compose environment
+	@read -r -p "Building the worker image takes a long time, do you want to proceed? (y/n) " CONTINUE; \
+    [ $$CONTINUE = "y" ] || [ $$CONTINUE = "Y" ] || (echo "Exiting docker image build."; exit 1;)
 	@echo "==> Building docker image..."
-	docker-compose $(docker_files) build
+	@docker-compose $(docker_files) build
 	@echo "    [✓]\n"
-run: # Runs the docker environment
+run: build # Runs the docker environment
 	@docker-compose $(docker_files) up
 logs: # Shows live logs if the workers are running or logs from last running worker if they are not.
 	@docker-compose $(docker_files) logs -f


### PR DESCRIPTION
# Background
#### Link to issue 

This is the issue that will have to be solved in the future https://biomage.atlassian.net/browse/BIOMAGE-872

# Changes
### Code changes

The docker build command setup (different for mac / linux) was not working in mac because the condition was flipped.

Added
* the original 2-dockerfile setup
* `make run` also builds the docker image (but asks for confirmation first)

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
