### PR TITLE
Remove library that is not used

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -81,7 +81,6 @@ PyYAML==5.4
 regex==2020.10.28
 requests==2.24.0
 responses==0.12.0
-rsa==4.6
 s3transfer==0.3.3
 scikit-learn==0.23.2
 scipy==1.5.3


### PR DESCRIPTION
# Background
The background is this PR that I saw raised by Dependabot: https://github.com/biomage-ltd/worker/pull/120
After a bit of looking around, I saw that the worker doesn't use this library at all. Instead of bumping it's version, it's best to remove it if it is not used.
There are lots of other libraries in the worker that are added as requirements and not used, long term we should clean them up and only have libraries that are used.

#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
