### PR TITLE
added makefile command to run the docker container without rebuilding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,9 @@ build: ## Builds the docker-compose environment
 	@echo "==> Building docker image..."
 	@docker-compose $(docker_files) build
 	@echo "    [✓]\n"
-run: build # Runs the docker environment
+run-only: # Runs the docker environment
+	@docker-compose $(docker_files) up
+run: build # Runs & builds the docker environment
 	@docker-compose $(docker_files) up
 logs: # Shows live logs if the workers are running or logs from last running worker if they are not.
 	@docker-compose $(docker_files) logs -f


### PR DESCRIPTION
I just added a `run-only` command to the makefile because I was using it. Normally only `run` should be used to ensure that the worker is up-to-date. However, if you have a slow connection and know what you're doing it's useful to just run it.