### PR TITLE
Remove default experiment ID

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
     ports:
       - "4000:4000"
     environment:
-      - EXPERIMENT_ID=${EXPERIMENT_ID-e52b39624588791a7889e39c617f669e}
+      - EXPERIMENT_ID=${EXPERIMENT_ID}
       - DEBUG_STEP=${DEBUG_STEP}
   python:
     container_name: "biomage-worker-python"
@@ -27,5 +27,5 @@ services:
       - ./python:/python:cached
       - ./data:/data:cached
     environment:
-      - EXPERIMENT_ID=${EXPERIMENT_ID-e52b39624588791a7889e39c617f669e}
+      - EXPERIMENT_ID=${EXPERIMENT_ID}
       - IGNORE_TIMEOUT=true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
     ports:
       - "4000:4000"
     environment:
-      - EXPERIMENT_ID=${EXPERIMENT_ID}
+      - EXPERIMENT_ID=${EXPERIMENT_ID-test}
       - DEBUG_STEP=${DEBUG_STEP}
   python:
     container_name: "biomage-worker-python"
@@ -27,5 +27,5 @@ services:
       - ./python:/python:cached
       - ./data:/data:cached
     environment:
-      - EXPERIMENT_ID=${EXPERIMENT_ID}
+      - EXPERIMENT_ID=${EXPERIMENT_ID-test}
       - IGNORE_TIMEOUT=true

--- a/python/src/config/__init__.py
+++ b/python/src/config/__init__.py
@@ -14,9 +14,7 @@ def get_config():
 
     aws_account_id = os.getenv("AWS_ACCOUNT_ID", default="242905224710")
     aws_region = os.getenv("AWS_DEFAULT_REGION", default="eu-west-1")
-    experiment_id = os.getenv(
-        "EXPERIMENT_ID", default="e52b39624588791a7889e39c617f669e"
-    )
+    experiment_id = os.getenv("EXPERIMENT_ID")
 
     # set up cluster env based on gitlab env if one was not specified
     # this is only run if `kube_env` is specified, i.e. when the system

--- a/python/src/tests/tasks/test_cluster_cells.py
+++ b/python/src/tests/tasks/test_cluster_cells.py
@@ -14,7 +14,7 @@ class TestClusterCells:
     @pytest.fixture(autouse=True)
     def load_correct_definition(self):
         self.correct_request = {
-            "experimentId": "e52b39624588791a7889e39c617f669e",
+            "experimentId": "test",
             "timeout": "2099-12-31 00:00:00",
             "body": {
                 "name": "ClusterCells",
@@ -25,7 +25,7 @@ class TestClusterCells:
             },
         }
         self.alternative_request = {
-            "experimentId": "e52b39624588791a7889e39c617f669e",
+            "experimentId": "test",
             "timeout": "2099-12-31 00:00:00",
             "body": {
                 "name": "ClusterCells",

--- a/python/src/tests/tasks/test_differential_expression.py
+++ b/python/src/tests/tasks/test_differential_expression.py
@@ -132,7 +132,7 @@ class TestDifferentialExpression:
         self, cellSet="cluster1", compareWith="rest", basis="all", maxNum=None
     ):
         request = {
-            "experimentId": "e52b39624588791a7889e39c617f669e1",
+            "experimentId": "test",
             "timeout": "2099-12-31 00:00:00",
             "body": {
                 "name": "DifferentialExpression",

--- a/python/src/tests/tasks/test_embedding.py
+++ b/python/src/tests/tasks/test_embedding.py
@@ -37,7 +37,7 @@ class TestEmbedding:
             }
         }
         """
-        The test file has been created with the multisample dataset, expId: e52b39624588791a7889e39c617f669e
+        The test file has been created with the multisample dataset, expId: test
         """
         self.correctResponse = json.load(open(os.path.join("tests", "emb_result.json")))
 

--- a/python/src/tests/tasks/test_gene_expression.py
+++ b/python/src/tests/tasks/test_gene_expression.py
@@ -13,7 +13,7 @@ class TestGeneExpression:
     @pytest.fixture(autouse=True)
     def load_correct_definition(self):
         self.correct_one_gene = {
-            "experimentId": "e52b39624588791a7889e39c617f669e",
+            "experimentId": "test",
             "timeout": "2099-12-31 00:00:00",
             "body": {
                 "name": "GeneExpression",
@@ -21,7 +21,7 @@ class TestGeneExpression:
             },
         }
         self.correct_request = {
-            "experimentId": "e52b39624588791a7889e39c617f669e",
+            "experimentId": "test",
             "timeout": "2099-12-31 00:00:00",
             "body": {
                 "name": "GeneExpression",

--- a/r/src/work.r
+++ b/r/src/work.r
@@ -12,7 +12,7 @@ source("./expression.r")
 source("./list_genes.r")
 source("./cluster.r")
 
-experiment_id <- Sys.getenv("EXPERIMENT_ID", unset = "e52b39624588791a7889e39c617f669e")
+experiment_id <- Sys.getenv("EXPERIMENT_ID")
 
 debug_step <- Sys.getenv("DEBUG_STEP", unset = "")
 # over-ride manually to hot-reload


### PR DESCRIPTION
As far as I can tell this is a vestige of when this experiment was the common test data. Now we don't test with only this (and it is not included in the repo), it is a misleading default that is confusing to new developers. With this change, `docker-compose up` without setting `EXPERIMENT_ID` will print `WARNING: The EXPERIMENT_ID variable is not set. Defaulting to a blank string.`, like it does for other important variables.
