### PR TITLE
Explicitly include task name in traceback

### DIFF
--- a/python/src/worker/tasks/factory.py
+++ b/python/src/worker/tasks/factory.py
@@ -43,9 +43,10 @@ class TaskFactory:
             result = task.compute()
             return result
         except Exception as e:
-            trace = traceback.format_exc()
-            error(trace)
+            trace = f"Exception for task {task.__class__.__name__}:\n" \
+                    f"{traceback.format_exc()}"
 
+            error(trace)
             xray_recorder.current_segment().add_exception(e, trace)
 
             # Only send real traces in development.


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here
For some reason, sometimes the traceback for an exception thrown during `task.compute()` does not include the file name of the specific task that threw the error. I noticed this just now. This change adds a line to the start of the traceback with the specific task that failed.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
