### PR TITLE
restarting only on R files changes

### DIFF
--- a/r/Dockerfile
+++ b/r/Dockerfile
@@ -58,4 +58,4 @@ RUN pip install -U jedi radian PyYAML watchdog[watchmedo]
 ADD R ./R
 COPY work.R .
 
-CMD watchmedo auto-restart --directory=. --pattern=* --recursive -- Rscript work.R
+CMD watchmedo auto-restart --directory=. --pattern='*.R' --recursive -- Rscript work.R

--- a/r/R/embedding.R
+++ b/r/R/embedding.R
@@ -48,13 +48,7 @@ runEmbedding <- function(req, data) {
                         perplexity = config$perplexity,
                         learning.rate = config$learningRate)
         df_embedding <- Embeddings(data, reduction = type)
-
-    } else if (type=="umap") {
-        # until we figure out why umap-learn and uwot break locally
-        env <- Sys.getenv('CLUSTER_ENV', 'development')
-        umap.method <- ifelse(env == 'development', 'uwot-learn', 'umap-learn')
-        message(sprintf('CLUSTER_ENV: %s --> UMAP method is: %s', env, umap.method))
-
+    } else if(type=="umap"){
         data <- RunUMAP(data,
                         seed.use = 42,
                         reduction=active.reduction,
@@ -62,7 +56,7 @@ runEmbedding <- function(req, data) {
                         verbose = F,
                         min.dist = config$minimumDistance,
                         metric = config$distanceMetric,
-                        umap.method = umap.method)
+                        umap.method = "umap-learn")
 
         df_embedding <- Embeddings(data, reduction = type)
     }


### PR DESCRIPTION
Fixing https://this-is-biomage.slack.com/archives/C015CHSUDRU/p1629133149006400

The issue is that some temporary files must be created so `watchmedo` triggers a restart of `Rscript work.R`. Adding the pattern `*.R` means that it will only restart for R files changes and that solves the issue.