### PR TITLE
[BIOMAGE-1393] Request redis endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 # Targets
 #--------------------------------------------------
 bootstrap: ## Installs requirements (python linter & formatter)
-	@pip install flake8 black
+	@pip install flake8 black isort
 fmt: ## Formats python files
 	@echo "==> Formatting files..."
 	@black --line-length 79 $(PYTHON_FILES)

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,5 +1,5 @@
 # pull official base image
-FROM python:3.7-buster AS builder
+FROM python:3.8-buster AS builder
 
 # set working directory
 WORKDIR /src

--- a/python/src/worker/config/__init__.py
+++ b/python/src/worker/config/__init__.py
@@ -69,6 +69,17 @@ class Config(types.SimpleNamespace):
     def SANDBOX_ID(self):
         return self.get_label('sandboxId')
 
+    @property
+    def WORK_QUEUE_HASH(self):
+        return self.get_label('workQueueHash')
+
+    @property
+    def QUEUE_NAME(self):
+        if cluster_env == "development" or cluster_env == "test":
+            return "development-queue.fifo"
+
+        return f"queue-job-{self.WORK_QUEUE_HASH}-{cluster_env}.fifo"
+
     @cached_property
     def REDIS_ENDPOINT(self):
         client = boto3.client("elasticache", **self.BOTO_RESOURCE_KWARGS)
@@ -95,13 +106,6 @@ class Config(types.SimpleNamespace):
             ssl=True,
             ssl_cert_reqs=None
         )
-
-    @property
-    def QUEUE_NAME(self):
-        if cluster_env == "development" or cluster_env == "test":
-            return "development-queue.fifo"
-
-        return f"queue-job-{self.get_label('workQueueHash')}-{cluster_env}.fifo"
 
 
 config = Config(


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1393
#### Link to staging deployment URL 
https://ui-james-worker195.scp-staging.biomage.net/
#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here
Upgraded to Python 3.8 to use `cached_property`. Tried 3.9 but this caused the installation of `leidenalg` to break.

Currently this works when I test locally but not in staging. Since Lens doesn't work for me I can't check out the logs myself right now.
# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
