### PR TITLE
Reduce worker alive time and bring back coverage report

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -196,18 +196,18 @@ jobs:
         env:
           R_IMAGE_NAME: ${{ format('{0}/{1}:{2}-r-ci', steps.login-ecr.outputs.registry, needs.build-docker.outputs.repo-name, needs.build-docker.outputs.tag) }}
 
-      # - id: test
-      #   name: Test, generate code coverage report and upload it
-      #   run: |-
-      #     pip install pytest-cov
-      #     ci_env=`bash <(curl -s https://codecov.io/env)`
+      - id: test
+        name: Test, generate code coverage report and upload it
+        run: |-
+          pip install pytest-cov
+          ci_env=`bash <(curl -s https://codecov.io/env)`
 
-      #     docker run -v /home/runner/work/worker/worker/data:/data $ci_env -e CI=true --env CLUSTER_ENV=test --net="host" --entrypoint /usr/bin/env $PYTHON_IMAGE_NAME /bin/bash -c "
-      #       python3 -m pytest --cov=. --cov-report=xml
-      #       bash <(curl -s https://codecov.io/bash)
-      #       "
-      #   env:
-      #     PYTHON_IMAGE_NAME: ${{ format('{0}/{1}:{2}-python-ci', steps.login-ecr.outputs.registry, needs.build-docker.outputs.repo-name, needs.build-docker.outputs.tag) }}
+          docker run -v /home/runner/work/worker/worker/data:/data $ci_env -e CI=true --env CLUSTER_ENV=test --net="host" --entrypoint /usr/bin/env $PYTHON_IMAGE_NAME /bin/bash -c "
+            python3 -m pytest --cov=. --cov-report=xml
+            bash <(curl -s https://codecov.io/bash)
+            "
+        env:
+          PYTHON_IMAGE_NAME: ${{ format('{0}/{1}:{2}-python-ci', steps.login-ecr.outputs.registry, needs.build-docker.outputs.repo-name, needs.build-docker.outputs.tag) }}
 
       - id: push
         name: Push docker images to ECR

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -293,7 +293,7 @@ jobs:
             SANDBOX_ID="STAGING_SANDBOX_ID"
             CHART_REF="STAGING_CHART_REF"
             KUBERNETES_ENV="staging"
-            REPLICA_COUNT="0"
+            REPLICA_COUNT="1"
             IMAGE_GLOB="${IMAGE_TAG/$GITHUB_SHA/*}"
             MEMORY_REQUEST="4Gi"
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -293,7 +293,7 @@ jobs:
             SANDBOX_ID="STAGING_SANDBOX_ID"
             CHART_REF="STAGING_CHART_REF"
             KUBERNETES_ENV="staging"
-            REPLICA_COUNT="1"
+            REPLICA_COUNT="0"
             IMAGE_GLOB="${IMAGE_TAG/$GITHUB_SHA/*}"
             MEMORY_REQUEST="4Gi"
           fi

--- a/python/src/worker/config/__init__.py
+++ b/python/src/worker/config/__init__.py
@@ -11,7 +11,7 @@ cluster_env = os.getenv("CLUSTER_ENV")
 timeout = int(
     os.getenv(
         "WORK_TIMEOUT",
-        default=str(60 * 60 * 6) if kube_env == "production" else str(60 * 60)
+        default=str(60 * 60 * 3) if kube_env == "production" else str(60 * 10)
     )
 )
 


### PR DESCRIPTION
# Background
#### Link to issue 
Our aws costs reports are still not great (from $500 per day it got reduced to $300, but that is still too much). Seems like the biggest impact on the costs are those staged environments, so I thought that reducing further the time when the worker is alive is going to help more. 
In the meantime I also noticed that the test coverage and the report has been commented out, so I brought it back.

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
