### PR TITLE
[BIOMAGE-1414] hotfix: Remove reference to non-existent value for worker scaler.

### DIFF
--- a/chart-infra/templates/scale-to-zero.yaml
+++ b/chart-infra/templates/scale-to-zero.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.clusterEnv "staging") (ne .Values.sandboxId "default") }}
+{{- if ne .Values.sandboxId "default" }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:


### PR DESCRIPTION
# Background
#### Link to issue
https://biomage.atlassian.net/browse/BIOMAGE-1414

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
https://github.com/biomage-ltd/worker/pull/204

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes
Fixes https://github.com/biomage-ltd/worker/pull/204 by deleting condition for nonexistent `.Values.clusterEnv` in the worker chart.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
