### PR TITLE
[BIOMAGE-1539] Fix handling of large work results

### DIFF
--- a/chart-infra/templates/scale-to-zero.yaml
+++ b/chart-infra/templates/scale-to-zero.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     sandboxId: "{{ .Values.sandboxId }}"
 spec:
-  schedule: '*/15 * * * *'
+  schedule: '*/60 * * * *'
   concurrencyPolicy: Replace
   jobTemplate:
     metadata:

--- a/python/src/worker/response.py
+++ b/python/src/worker/response.py
@@ -47,7 +47,9 @@ class Response:
     def _upload(self, response_msg):
         client = boto3.client("s3", **config.BOTO_RESOURCE_KWARGS)
         ETag = self.request["ETag"]
-        body = json.dumps(response_msg["results"][0]["body"])
+
+        updatedResponseMsg = {"cacheable": response_msg["response"]["cacheable"], "data": json.loads(response_msg["results"][0]["body"])}
+        body = json.dumps(updatedResponseMsg)
 
         # Disabled X-Ray to fix a botocore bug where the context
         # does not propagate to S3 requests. see:

--- a/python/src/worker/response.py
+++ b/python/src/worker/response.py
@@ -47,7 +47,7 @@ class Response:
     def _upload(self, response_msg):
         client = boto3.client("s3", **config.BOTO_RESOURCE_KWARGS)
         ETag = self.request["ETag"]
-        body = json.dumps(response_msg)
+        body = json.dumps(response_msg["results"][0]["body"])
 
         # Disabled X-Ray to fix a botocore bug where the context
         # does not propagate to S3 requests. see:


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1539

#### Link to staging deployment URL 
https://ui-martinfosco-ui538-worker20.scp-staging.biomage.net/

#### Links to any Pull Requests related to this
https://github.com/biomage-ltd/ui/pull/538

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
