### PR TITLE
[BIOMAGE-1560] Removing worker cleanup operator removed rights of scale to zero cronjob

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -293,7 +293,7 @@ jobs:
             SANDBOX_ID="STAGING_SANDBOX_ID"
             CHART_REF="STAGING_CHART_REF"
             KUBERNETES_ENV="staging"
-            REPLICA_COUNT="1"
+            REPLICA_COUNT="0"
             IMAGE_GLOB="${IMAGE_TAG/$GITHUB_SHA/*}"
             MEMORY_REQUEST="4Gi"
           fi

--- a/chart-infra/templates/scale-to-zero.yaml
+++ b/chart-infra/templates/scale-to-zero.yaml
@@ -28,7 +28,37 @@ spec:
                 - worker
               resources: {}
           restartPolicy: Never
-          serviceAccountName: cleanup-operator
-          serviceAccount: cleanup-operator
+          serviceAccountName: scale-to-zero-operator
+          serviceAccount: scale-to-zero-operator
   successfulJobsHistoryLimit: 1
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scale-to-zero-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: scale-to-zero-operator
+rules:
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  - deployments/scale
+  verbs:
+  - get
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: scale-to-zero-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: scale-to-zero-operator
+subjects:
+- kind: ServiceAccount
+  name: scale-to-zero-operator
 {{- end }}


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1560

#### Link to staging deployment URL 
https://ui-marcellp-worker213.scp-staging.biomage.net/

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
Fixes a bug introduced in c20ea226cba99e9b40ecd8cc179c86c7115d2540 where the cleanup-operator account was deleted which was also used by the scale-to-zero operator.

# Changes
### Code changes
Created a special service account, role, and role binding for the scale-down operator that is now attached to the same file as the CronJob that runs it to make the dependency explicit.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
