### PR TITLE
[BIOMAGE-1254] added filter check

### DIFF
--- a/python/src/worker/tasks/differential_expression.py
+++ b/python/src/worker/tasks/differential_expression.py
@@ -96,7 +96,7 @@ class DifferentialExpression(Task):
         if self.pagination:
             request["pagination"] = self.pagination
 
-        if "filters" in self.pagination:
+        if "filters" in self.pagination and self.pagination["filters"][0]["type"] == "text":
             gene_filter = self.pagination["filters"][0]["expression"]
             request["geneNamesFilter"] = remove_regex(gene_filter)
 
@@ -134,5 +134,5 @@ class DifferentialExpression(Task):
         #  will fail
         r.raise_for_status()
         r = r.json()
-
+        
         return self._format_result(r)


### PR DESCRIPTION
# Background
We have 2 types of filters in DE - text for filtering gene names and numeric - advanced filtering menu. The numeric request does not have some fields that a text one has and a check is needed so the operations are  not executed
#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
