### PR TITLE
Add development dependencies to suggests and renv ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ export GITHUB_API_TOKEN=<your-token>
 ```
 
 ### Running tests
+
+#### python worker
 Assuming the containers are running, you can execute the (pytest) unit tests using:
 
     make test
@@ -52,6 +54,10 @@ See [here](python/README.md#tests) for more information about the tests.
 To shut down the development containers, you can use:
 
     make kill
+
+#### R worker
+
+Refer to the [R-worker README](r/README.md#running-r-worker-tests).
 
 ### Remote - Containers
 Development is done inside a development container that is automatically built,

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -5,9 +5,6 @@ Authors@R:
     person(given = "First",
            family = "Last",
            role = c("aut", "cre"),
-        person(given = "First",
-           family = "Last",
-           role = c("aut", "cre"),
            email = "first.last@example.com",
            comment = c(ORCID = "YOUR-ORCID-ID"))
 Description: What the package does (one paragraph).

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -2,25 +2,27 @@ Package: rworker
 Title: What the Package Does (One Line, Title Case)
 Version: 0.0.0.9000
 Authors@R: 
-    person(given = "First",
-           family = "Last",
-           role = c("aut", "cre"),
-           email = "first.last@example.com",
+    person("First", "Last", , "first.last@example.com", role = c("aut", "cre"),
            comment = c(ORCID = "YOUR-ORCID-ID"))
 Description: What the package does (one paragraph).
 License: `use_mit_license()`, `use_gpl3_license()` or friends to pick a
     license
-Encoding: UTF-8
-LazyData: true
-Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+Depends: 
+    R (>= 4.2.0)
 Imports:
     covr,
     xml2
 Suggests: 
+    devtools,
     httptest,
+    languageserver,
+    roxygen2,
     statmod,
-    testthat (>= 3.0.0)
+    styler,
+    testthat (>= 3.0.0),
+    usethis
 Config/testthat/edition: 3
-Depends: 
-    R (>= 2.10)
+Encoding: UTF-8
+LazyData: true
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.2.0

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -2,7 +2,10 @@ Package: rworker
 Title: What the Package Does (One Line, Title Case)
 Version: 0.0.0.9000
 Authors@R: 
-    person("First", "Last", , "first.last@example.com", role = c("aut", "cre"),
+    person(given = "First",
+           family = "Last",
+           role = c("aut", "cre"),
+           email = "first.last@example.com",
            comment = c(ORCID = "YOUR-ORCID-ID"))
 Description: What the package does (one paragraph).
 License: `use_mit_license()`, `use_gpl3_license()` or friends to pick a

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -5,6 +5,9 @@ Authors@R:
     person(given = "First",
            family = "Last",
            role = c("aut", "cre"),
+        person(given = "First",
+           family = "Last",
+           role = c("aut", "cre"),
            email = "first.last@example.com",
            comment = c(ORCID = "YOUR-ORCID-ID"))
 Description: What the package does (one paragraph).

--- a/r/README.md
+++ b/r/README.md
@@ -25,11 +25,19 @@ Some packages on MacOS X requires the Fortran compiler to compile. According to 
 
 The R worker is provided as a RStudio project, complete with a `renv`
 definition. It might be useful to run things interactively in certain
-development scenarios; to do so, you should have the correct R version installed (check `renv.lock.init` file for it). Open the `.Rproj` file with Rstudio and run in the R terminal:
+development scenarios; to do so, you should have the correct R version installed (check `renv.lock` file for it). Open the `.Rproj` file with Rstudio and run in the R terminal:
 
     renv::restore()
 
-Most of the development is done using RStudio. To
+In addition, dependencies for interactive development are specified in the DESCRIPTION file, under
+the `Suggests` section. They, and their dependencies are ignored by renv (specified in the
+[renv settings file](renv/settings.dcf) file).
+
+They can be installed automatically by running the next block in an R console.
+
+```{r}
+    renv::install() # (without arguments)
+```
 
 ### Development with Visual Studio Code
 

--- a/r/renv/settings.dcf
+++ b/r/renv/settings.dcf
@@ -1,8 +1,10 @@
+bioconductor.version:
 external.libraries:
-ignored.packages:
+ignored.packages: devtools, languageserver, roxygen2, styler, usethis
 package.dependency.fields: Imports, Depends, LinkingTo
 r.version:
 snapshot.type: implicit
 use.cache: TRUE
+vcs.ignore.cellar: TRUE
 vcs.ignore.library: TRUE
 vcs.ignore.local: TRUE


### PR DESCRIPTION
# Description
This PR adds packages used for interactive development, such as devtools, roxygen2 and usethis to the list of packages ignored by renv. This has the advantage of allowing developers to have this packages installed, without adding them to the renv.lock file (this includes their dependencies!). They are not necessary at runtime.

Finally, added these devel packages to the Suggest section of the DESCRIPTION file (as is recommended, both by [renv documentation](https://rstudio.github.io/renv/articles/faq.html#how-should-i-handle-development-dependencies) and the [R packages book](https://r-pkgs.org/description-dependencies.html#run-time-vs-develop-time-dependencies). This allows us to install runtime dependencies as usual, using renv::restore() and additionally install the devel dependencies, using renv::install() (with no arguments, it installs the packages listed in the DESCRIPTION FILE)

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
https://github.com/hms-dbmi-cellenics/pipeline/pull/257
https://github.com/hms-dbmi-cellenics/pipeline/pull/263

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [x] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [x] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [x] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `biomage experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [x] Started end-to-end tests on the latest commit.

### Documentation updates
- [x] Relevant Github READMEs updated **or** no GitHub README updates required.
- [x] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.