### PR TITLE
fix buildcache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,29 +198,22 @@ jobs:
         env:
           REPO_NAME: ${{ steps.ref.outputs.repo-name }}
 
-      - id: pull-latest-image
-        name: Pull latest Docker images from mainline
-        run: |-
-          echo Pulling $IMAGE_NAME from ECR.
-          docker pull $IMAGE_NAME || true
-
-          echo Pulling $IMAGE_NAME-builder from ECR.
-          docker pull $IMAGE_NAME-builder || true
-
-        env:
-          IMAGE_NAME: ${{ format('{0}/{1}:{2}-{3}', steps.login-ecr.outputs.registry, steps.ref.outputs.repo-name, steps.ref-previous.outputs.tag, matrix.project) }}
+      - id: setup-docker-buildx
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - id: build
         name: Build Docker images
         run: |-
-          docker build --target builder \
-            --cache-from=$PREVIOUS_IMAGE_NAME-builder \
+          docker buildx build --target builder \
+            --output=type=docker \
+            --cache-from type=registry,ref=$PREVIOUS_IMAGE_NAME-builder \
             --build-arg GITHUB_PAT=$GITHUB_PAT \
             --tag $IMAGE_NAME-builder .
 
-          docker build --target prod \
+          docker buildx build --target prod \
+            --output=type=docker \
             --cache-from=$IMAGE_NAME-builder \
-            --cache-from=$PREVIOUS_IMAGE_NAME \
             --build-arg GITHUB_PAT=$GITHUB_PAT \
             --tag $IMAGE_NAME-ci .
         env:
@@ -232,13 +225,16 @@ jobs:
         name: Push builder images to ECR
         run: |-
           echo Pushing image $IMAGE_NAME-builder to ECR.
-          docker push $IMAGE_NAME-builder
+          docker buildx build --push --target builder \
+            --cache-to type=registry,ref=$IMAGE_NAME-builder,mode=max,image-manifest=true \
+            --build-arg GITHUB_PAT=$GITHUB_PAT \
+            --tag $IMAGE_NAME-builder .
 
           echo Pushing image $IMAGE_NAME-ci to ECR.
           docker push $IMAGE_NAME-ci
         env:
           IMAGE_NAME: ${{ format('{0}/{1}:{2}-{3}', steps.login-ecr.outputs.registry, steps.ref.outputs.repo-name, steps.ref.outputs.image-tag, matrix.project) }}
-
+          GITHUB_PAT: ${{ secrets.API_TOKEN_GITHUB }}
   test:
     name: Run tests
     # to ensure compatibility with the sqlite found in the


### PR DESCRIPTION
# Description
fixes docker buildcache so images dont need full rebuild on every commit.

**not sure if necessary - waiting to see if some fixes from Martin resolve this as well**

**NOTES**: 
- no way AFAIK to tell if it works based on PR (ci.yaml runs as master for PRs)
- tested locally:
  - setup buildx manually: `docker buildx create --use --driver=docker-container`
  - run `docker buildx build ...` commands
  - run `docker buildx build --push ...` command to push buildcache to ECR
  - run `docker push ...` command to push regular image to ECR
  - re-run `docker buildx build ...` command after pruning buildx cache to check that it uses the cache


# Details
#### URL to issue
https://github.com/hms-dbmi-cellenics/issues/issues/21

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
https://github.com/hms-dbmi-cellenics/pipeline/pull/325

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.