### PR TITLE
fix(scType): marking resp as cacheable so it is uploaded to S3

### DIFF
--- a/python/src/worker/tasks/cell_annotation_sctype.py
+++ b/python/src/worker/tasks/cell_annotation_sctype.py
@@ -11,6 +11,7 @@ from ..helpers.cell_sets_dict import get_cell_sets_dict_for_r
 from ..result import Result
 from ..tasks import Task
 
+
 class ScTypeAnnotate(Task):
     def __init__(self, msg):
         super().__init__(msg)
@@ -18,7 +19,7 @@ class ScTypeAnnotate(Task):
         self.request = msg
 
     def _format_result(self, result):
-        return Result(result, cacheable=False)
+        return Result(result, cacheable=True)
 
     def _format_request(self):
         # get cell sets from database
@@ -28,15 +29,14 @@ class ScTypeAnnotate(Task):
         species = self.task_def["species"]
         tissue = self.task_def["tissue"]
 
-        return { 
+        return {
             "cellSets": cell_sets_dict,
-            "species": species, 
-            "tissue": tissue, 
-            "apiUrl" : config.API_URL, 
-            "authJwt" : self.request["Authorization"],
-            "experimentId": self.experiment_id
+            "species": species,
+            "tissue": tissue,
+            "apiUrl": config.API_URL,
+            "authJwt": self.request["Authorization"],
+            "experimentId": self.experiment_id,
         }
-
 
     @xray_recorder.capture("ScTypeAnnotate.compute")
     @backoff.on_exception(
@@ -58,4 +58,3 @@ class ScTypeAnnotate(Task):
         data = result.get("data")
 
         return self._format_result(data)
-


### PR DESCRIPTION
# Description

The worker improvements broke the communication model with the worker (which was already overly complicated and extremely inconsistent). The issue for scType is:
1. ScType results are sent via API updating the cellsets
2. However, the task is marked as "non-cacheable" so data the work result is never uploaded (or sent via socket) 
3. Even if it's not cacheable, the worker sends the signed URL anyway causing the UI to try to download a file that does not exit (because of 2) and which actually does not need (because they are retrieved via 1)

The issue can be solved just marking `scType` as cacheable, but this is broken paradigm. I don't know why cluster cells and embeddings are not failing too, as they are in the same condition. My current guess is that they also fail and be the reason why when landing in data exploration sometimes you briefly see "Try again errors" but somehow the UI recovers.

# Details
#### URL to issue
https://github.com/hms-dbmi-cellenics/issues/issues/73

#### Link to staging deployment URL (or set N/A)
<!---
  Delete this comment and include the URL of the staging environment for this pull request.
  Refer to https://github.com/hms-dbmi-cellenics/cellenics-utils#stage on how to stage a staging environment.
  If a staging environment for testing is not necessary for this PR, replace this comment with N/A 
  and explain why a staging environment is not required for this PR.

  Your pull request will not pass the required checks if this is not followed.
-->

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.
