### PR TITLE
Add correct reduction names in downloaded Seurat object

### DIFF
--- a/python/src/tests/tasks/test_download_annot_seurat_object.py
+++ b/python/src/tests/tasks/test_download_annot_seurat_object.py
@@ -30,7 +30,8 @@ class TestDownloadAnnotSeuratObject:
             "Authorization" : "mock_authJwt",
             "body": {
                 "name": "DownloadAnnotSeuratObject",
-                "embeddingETag": mock_embedding_etag
+                "embeddingETag": mock_embedding_etag,
+                "embeddingMethod": "umap"
             }
         }
 
@@ -142,6 +143,7 @@ class TestDownloadAnnotSeuratObject:
             expected_keys = [
                 "embedding",
                 "cellSets",
+                "embeddingMethod",
                 ]
             assert all(key in request for key in expected_keys)
             stubber.assert_no_pending_responses()

--- a/python/src/worker/tasks/download_annot_seurat_object.py
+++ b/python/src/worker/tasks/download_annot_seurat_object.py
@@ -29,10 +29,12 @@ class DownloadAnnotSeuratObject(Task):
 
         embedding_etag = self.task_def["embeddingETag"]
         embedding = get_embedding(embedding_etag, format_for_r=True)
+        embedding_method = self.task_def["embeddingMethod"] 
 
         request = {
             "embedding": embedding,
             "cellSets": cell_sets_dict,
+            "embeddingMethod": embedding_method,
         }
 
         return request

--- a/r/R/download_annot_seurat_object.R
+++ b/r/R/download_annot_seurat_object.R
@@ -17,11 +17,10 @@
 DownloadAnnotSeuratObject <- function(req, data) {
   cell_sets <- req$body$cellSets
   embedding_data <- req$body$embedding
-
-  reduction <- ifelse(embedding_data[[1]] == c(0,0), "umap", ifelse(embedding_data[[1]] == c(1,1), "tsne", "umap"))[1]
+  embedding_method <- req$body$embeddingMethod
 
   data <- add_cellsets(data, cell_sets)
-  data <- assignEmbedding(embedding_data, data, reduction)
+  data <- assignEmbedding(embedding_data, data, embedding_method)
 
   saveRDS(data, RDS_PATH)
 

--- a/r/R/download_annot_seurat_object.R
+++ b/r/R/download_annot_seurat_object.R
@@ -18,8 +18,10 @@ DownloadAnnotSeuratObject <- function(req, data) {
   cell_sets <- req$body$cellSets
   embedding_data <- req$body$embedding
 
+  reduction <- ifelse(embedding_data[[1]] == c(0,0), "umap", ifelse(embedding_data[[1]] == c(1,1), "tsne", "umap"))[1]
+
   data <- add_cellsets(data, cell_sets)
-  data <- assignEmbedding(embedding_data, data)
+  data <- assignEmbedding(embedding_data, data, reduction)
 
   saveRDS(data, RDS_PATH)
 
@@ -38,10 +40,10 @@ add_cellsets <- function(scdata, cellsets) {
     children <- cellset$children
     if (!length(children)) next()
 
-  if (uuid::UUIDvalidate(cellset$key)) {
-        key <- cellset$name
+    if (uuid::UUIDvalidate(cellset$key)) {
+      key <- cellset$name
     } else {
-        key <- cellset$key
+      key <- cellset$key
     }
 
     scdata[[key]] <- NA_character_

--- a/r/R/embedding.R
+++ b/r/R/embedding.R
@@ -55,12 +55,6 @@ runEmbedding <- function(req, data) {
     tidyr::complete(cells_id = seq(0, max(data@meta.data$cells_id))) %>%
     dplyr::select(-cells_id)
 
-  # Add reduction method identifier
-  col_names <- colnames(df_embedding)
-  red_id <- ifelse(grepl("umap", col_names, ignore.case = T), 0, ifelse(grepl("tsne", col_names, ignore.case = T), 1, 2))
-  red_id <- setNames(red_id, col_names)
-  df_embedding <- dplyr::bind_rows(red_id, df_embedding)
-
   map2_fun <- function(x, y) {
     if (is.na(x)) {
       return(NULL)
@@ -114,9 +108,6 @@ getEmbedding <- function(config, method, reduction_type, num_pcs, data) {
 assignEmbedding <- function(embedding_data, data, reduction_method = "umap") {
   cells_id <- data@meta.data$cells_id
   embedding <- do.call(rbind, embedding_data)
-
-  # First row is reduction method identifier
-  embedding <- embedding[-1, ]
 
   # Add 1 to cells_id because it's 0-index and embeddings is not.
   embedding <- embedding[cells_id + 1, ]

--- a/r/R/embedding.R
+++ b/r/R/embedding.R
@@ -113,12 +113,13 @@ assignEmbedding <- function(embedding_data, data, reduction_method = "umap") {
   embedding <- embedding[cells_id + 1, ]
   rownames(embedding) <- colnames(data)
 
-  embedding_key <- "UMAP_"
-  if (reduction_method == "tsne") {
-    embedding_key <- "tSNE_"
-  }
+  reduction_keys <- list(
+    "umap" = "UMAP_",
+    "tsne" = "tSNE_"
+  )
+  embedding_key <- unname(unlist(reduction_keys[reduction_method]))
 
-  colnames(embedding) <- c(paste0(embedding_key, "1"), paste0(embedding_key, "2"))
+  colnames(embedding) <- paste(embedding_key, 1:2, sep = "")
   data[[reduction_method]] <- Seurat::CreateDimReducObject(embeddings = embedding, key = embedding_key)
 
   return(data)

--- a/r/tests/testthat/test-download_annot_seurat_object.R
+++ b/r/tests/testthat/test-download_annot_seurat_object.R
@@ -128,11 +128,12 @@ mock_embedding_data <- function(data) {
   return(embedding_data)
 }
 
-mock_req <- function(data) {
+mock_req <- function(data, reduction = "umap") {
   req <- list(
     body = list(
       cellSets = mock_cellset_from_python(data),
-      embedding = mock_embedding_data(data)
+      embedding = mock_embedding_data(data),
+      embeddingMethod = reduction
     )
   )
 


### PR DESCRIPTION
# Description
When downloading the rds file that contains the Seurat object, the dimensionality reduction name is invariably set to "umap" even in instances where t-SNE has been applied.
When the embeddings are calculated, converted to json, and sent to S3, the information on which method was used to generate them (which is in the column names) is lost. This PR is to use the reduction method from the request.

Staging: https://ui-sara-ui57-api22-worker21.scp-staging.biomage.net/

# Details
#### URL to issue
https://github.com/hms-dbmi-cellenics/issues/issues/89

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
https://github.com/hms-dbmi-cellenics/ui/pull/953
https://github.com/hms-dbmi-cellenics/api/pull/510

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [x] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.
